### PR TITLE
release: v2.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "loki"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "arrayvec",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loki"
-version = "2.10.0"
+version = "2.11.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary
- bump the package version from `2.10.0` to `2.11.0`
- prepare `master` for the next tag-driven release build

## Included Since v2.10.0
- dependency refresh and tracked `Cargo.lock`
- YARA-Forge Core as the default signature update source
- expanded automated test coverage
- Linux process memory hardening for unsafe device-backed mappings

## Validation
- cargo test --tests -- --nocapture
- cargo run --bin loki -- --version
- cargo run --bin loki-util --