### PR TITLE
fix: handle Windows scan paths with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ sudo ./loki --remote syslog-host.internal:514 --remote-proto udp
 ### Scan Target
 | Option | Default | Description |
 |--------|---------|-------------|
-| `-f, --folder <PATH>` | `/` | Folder to scan |
+| `-f, --folder <PATH>` | `/` | Folder to scan. Quote paths containing spaces, e.g. `-f "J:\SteamLibrary\steamapps\common\SpaceCraft beta"` |
 
 ### Scan Control
 | Option | Default | Description |

--- a/USAGE.md
+++ b/USAGE.md
@@ -55,6 +55,11 @@ Options:
 ./build/loki -f /path/to/scan
 ```
 
+### Scan a Windows directory with spaces:
+```powershell
+.\loki.exe -f "J:\SteamLibrary\steamapps\common\SpaceCraft beta"
+```
+
 ### Scan with debug output:
 ```bash
 ./build/loki -d -f /path/to/scan
@@ -225,4 +230,3 @@ See `README.md` for detailed build instructions and requirements.
 ## License
 
 See `LICENSE` file for license information.
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,8 @@ struct Cli {
     // SCAN TARGET
     // =========================================================================
     
-    /// Folder to scan (default: entire system)
-    #[arg(short = 'f', long, help_heading = "Scan Target")]
+    /// Folder to scan (quote paths containing spaces)
+    #[arg(short = 'f', long, value_name = "PATH", help_heading = "Scan Target")]
     folder: Option<String>,
 
     // =========================================================================

--- a/src/modules/filesystem_scan.rs
+++ b/src/modules/filesystem_scan.rs
@@ -161,15 +161,47 @@ fn is_cloud_or_remote_path(path: &str) -> bool {
     false
 }
 
+#[cfg(any(windows, test))]
+fn windows_drive_root(path: &str) -> Option<String> {
+    let path = path.trim_matches('"').replace('/', "\\");
+
+    if path.len() >= 6 && path[..4].eq_ignore_ascii_case(r"\\?\") {
+        let bytes = path.as_bytes();
+        if bytes.get(4).is_some_and(|b| b.is_ascii_alphabetic()) && bytes.get(5) == Some(&b':') {
+            return Some(format!(r"\\?\{}:\", bytes[4] as char));
+        }
+    }
+
+    if path.len() >= 8 && path[..8].eq_ignore_ascii_case(r"\\?\UNC\") {
+        let rest = &path[8..];
+        let mut parts = rest.split('\\').filter(|part| !part.is_empty());
+        let server = parts.next()?;
+        let share = parts.next()?;
+        return Some(format!(r"\\?\UNC\{}\{}\", server, share));
+    }
+
+    if let Some(rest) = path.strip_prefix(r"\\") {
+        let mut parts = rest.split('\\').filter(|part| !part.is_empty());
+        let server = parts.next()?;
+        let share = parts.next()?;
+        return Some(format!(r"\\{}\{}\", server, share));
+    }
+
+    let bytes = path.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        return Some(format!("{}:\\", bytes[0] as char));
+    }
+
+    None
+}
+
 // Check if a root path is a network drive (Windows only)
 #[cfg(windows)]
 fn is_network_drive(path: &str) -> bool {
-    // Need a root path like "C:\" or "\\server\share"
-    // If path is just a letter "C:", append backslash
-    let root = if path.len() == 2 && path.chars().nth(1) == Some(':') {
-        format!("{}\\", path)
-    } else {
-        path.to_string()
+    // GetDriveTypeW expects a root such as "C:\" or "\\server\share\".
+    // Passing a full path can return DRIVE_NO_ROOT_DIR and falsely look remote.
+    let Some(root) = windows_drive_root(path) else {
+        return false;
     };
     
     let h_root = HSTRING::from(&root);
@@ -1189,6 +1221,41 @@ mod tests {
 
     mod path_exclusion_tests {
         use super::*;
+
+        #[test]
+        fn test_windows_drive_root_from_full_path_with_spaces() {
+            let path = r"J:\SteamLibrary\steamapps\common\SpaceCraft beta";
+            assert_eq!(windows_drive_root(path).as_deref(), Some(r"J:\"));
+        }
+
+        #[test]
+        fn test_windows_drive_root_from_forward_slashes() {
+            let path = "J:/SteamLibrary/steamapps/common/SpaceCraft beta";
+            assert_eq!(windows_drive_root(path).as_deref(), Some(r"J:\"));
+        }
+
+        #[test]
+        fn test_windows_drive_root_from_drive_only() {
+            assert_eq!(windows_drive_root("J:").as_deref(), Some(r"J:\"));
+        }
+
+        #[test]
+        fn test_windows_drive_root_from_unc_path() {
+            let path = r"\\server\share\SteamLibrary\steamapps\common\SpaceCraft beta";
+            assert_eq!(
+                windows_drive_root(path).as_deref(),
+                Some(r"\\server\share\")
+            );
+        }
+
+        #[test]
+        fn test_windows_drive_root_from_extended_unc_path() {
+            let path = r"\\?\UNC\server\share\SteamLibrary\SpaceCraft beta";
+            assert_eq!(
+                windows_drive_root(path).as_deref(),
+                Some(r"\\?\UNC\server\share\")
+            );
+        }
 
         #[test]
         fn test_linux_path_skips_proc() {

--- a/tests/scanning_tests/test_simple_scan.sh
+++ b/tests/scanning_tests/test_simple_scan.sh
@@ -19,6 +19,10 @@ echo "Creating test files in $TEST_DIR..."
 echo "This is a test file" > "$TEST_DIR/test.txt"
 echo "Another test file" > "$TEST_DIR/another.txt"
 
+SPACE_DIR="$TEST_DIR/SpaceCraft beta"
+mkdir -p "$SPACE_DIR"
+echo "echo spacecraft beta" > "$SPACE_DIR/launcher.bat"
+
 # Test basic scan (using --no-fs is wrong - we want to scan the filesystem!)
 # Just run a simple scan on the test directory with --no-procs to skip process scanning
 echo "Testing basic scan on test directory..."
@@ -34,6 +38,21 @@ else
     echo "  Expected: Output containing scan progress/completion messages"
     echo "  Actual output:"
     echo "$scan_output"
+    test_passed=false
+fi
+
+# Test a folder path containing spaces. This catches shell quoting and CLI
+# argument handling regressions for Windows-style game/install folder names.
+echo "Testing scan on directory with spaces..."
+space_scan_output=$(./build/loki -f "$SPACE_DIR" --no-procs --no-tui --no-html --no-log --no-jsonl 2>&1) || true
+
+if echo "$space_scan_output" | grep -qE "(LOKI scan started|Scan completed|Files scanned)"; then
+    echo "✓ Path with spaces scan: PASS"
+else
+    echo "✗ Path with spaces scan: FAIL"
+    echo "  Expected: Output containing scan progress/completion messages"
+    echo "  Actual output:"
+    echo "$space_scan_output"
     test_passed=false
 fi
 


### PR DESCRIPTION
## Summary
- document quoting for scan paths that contain spaces, including a Windows Steam path example
- normalize Windows scan targets to drive/share roots before calling `GetDriveTypeW` to avoid false network-drive warnings
- add regression coverage for Windows root parsing and scanning a folder named `SpaceCraft beta`

## Testing
- cargo test windows_drive_root --bin loki
- cargo build --bin loki
- git diff --check
- target/debug/loki --help | sed -n '/Scan Target/,+4p'