### PR TITLE
fix: address security review findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build/
 config/excludes.cfg
 loki-logs/*
 .claude/settings.local.json
+loki_rune_*.jsonl

--- a/src/helpers/html_report.rs
+++ b/src/helpers/html_report.rs
@@ -1831,23 +1831,26 @@ fn render_finding_card(finding: &LogEvent, idx: usize) -> String {
     }
     
     if let Some(ref md5) = finding.md5 {
+        let md5_filter = js_string_for_html_attr(md5);
         details_html.push_str(&format!(
-            r#"<div class="detail-item-hash"><span class="detail-label">MD5:</span> <a href="https://www.virustotal.com/gui/search/{}" target="_blank" class="detail-value hash-link" title="Search on VirusTotal">{}</a><button class="filter-btn-inline" onclick="filterValue('{}', event)" title="Filter out this hash">✖</button></div>"#,
-            html_escape(md5), html_escape(md5), html_escape(md5)
+            r#"<div class="detail-item-hash"><span class="detail-label">MD5:</span> <a href="https://www.virustotal.com/gui/search/{}" target="_blank" class="detail-value hash-link" title="Search on VirusTotal">{}</a><button class="filter-btn-inline" onclick="filterValue({}, event)" title="Filter out this hash">✖</button></div>"#,
+            html_escape(md5), html_escape(md5), md5_filter
         ));
     }
     
     if let Some(ref sha1) = finding.sha1 {
+        let sha1_filter = js_string_for_html_attr(sha1);
         details_html.push_str(&format!(
-            r#"<div class="detail-item-hash"><span class="detail-label">SHA1:</span> <a href="https://www.virustotal.com/gui/search/{}" target="_blank" class="detail-value hash-link" title="Search on VirusTotal">{}</a><button class="filter-btn-inline" onclick="filterValue('{}', event)" title="Filter out this hash">✖</button></div>"#,
-            html_escape(sha1), html_escape(sha1), html_escape(sha1)
+            r#"<div class="detail-item-hash"><span class="detail-label">SHA1:</span> <a href="https://www.virustotal.com/gui/search/{}" target="_blank" class="detail-value hash-link" title="Search on VirusTotal">{}</a><button class="filter-btn-inline" onclick="filterValue({}, event)" title="Filter out this hash">✖</button></div>"#,
+            html_escape(sha1), html_escape(sha1), sha1_filter
         ));
     }
     
     if let Some(ref sha256) = finding.sha256 {
+        let sha256_filter = js_string_for_html_attr(sha256);
         details_html.push_str(&format!(
-            r#"<div class="detail-item-hash"><span class="detail-label">SHA256:</span> <a href="https://www.virustotal.com/gui/search/{}" target="_blank" class="detail-value hash-link" title="Search on VirusTotal">{}</a><button class="filter-btn-inline" onclick="filterValue('{}', event)" title="Filter out this hash">✖</button></div>"#,
-            html_escape(sha256), html_escape(sha256), html_escape(sha256)
+            r#"<div class="detail-item-hash"><span class="detail-label">SHA256:</span> <a href="https://www.virustotal.com/gui/search/{}" target="_blank" class="detail-value hash-link" title="Search on VirusTotal">{}</a><button class="filter-btn-inline" onclick="filterValue({}, event)" title="Filter out this hash">✖</button></div>"#,
+            html_escape(sha256), html_escape(sha256), sha256_filter
         ));
     }
     
@@ -1868,8 +1871,8 @@ fn render_finding_card(finding: &LogEvent, idx: usize) -> String {
             };
             
             let filter_btn = if let Some(ref rn) = rule_name {
-                let escaped_rule = rn.replace('\'', "\\'");
-                format!(r#"<button class="filter-btn-inline" onclick="filterValue('{}', event)" title="Filter out this rule">✖</button>"#, escaped_rule)
+                let escaped_rule = js_string_for_html_attr(rn);
+                format!(r#"<button class="filter-btn-inline" onclick="filterValue({}, event)" title="Filter out this rule">✖</button>"#, escaped_rule)
             } else {
                 String::new()
             };
@@ -1964,15 +1967,14 @@ fn render_finding_card(finding: &LogEvent, idx: usize) -> String {
     let raw_json = serde_json::to_string_pretty(finding).unwrap_or_default();
     let highlighted_json = syntax_highlight_json(&raw_json);
     
-    // Create a JavaScript-safe version of the path for the onclick handler
-    let path_js_escaped = path_or_name.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n");
+    let path_js_escaped = js_string_for_html_attr(path_or_name);
     
     format!(
         r#"<div class="finding-card" data-level="{level_class}" id="finding-{idx}">
             <div class="finding-header">
                 <span class="severity-badge {level_class}">{level}</span>
                 <span class="score">{score}</span>
-                <span class="finding-path">{path}<button class="filter-btn-inline" onclick="filterValue('{path_js}', event)" title="Filter out this path">✖</button></span>
+                <span class="finding-path">{path}<button class="filter-btn-inline" onclick="filterValue({path_js}, event)" title="Filter out this path">✖</button></span>
                 <span class="finding-type">{finding_type}</span>
             </div>
             <div class="finding-body">
@@ -2010,6 +2012,11 @@ fn html_escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&#39;")
+}
+
+fn js_string_for_html_attr(s: &str) -> String {
+    let json_string = serde_json::to_string(s).unwrap_or_else(|_| "\"\"".to_string());
+    html_escape(&json_string)
 }
 
 fn format_size(bytes: usize) -> String {
@@ -2244,5 +2251,49 @@ mod tests {
         assert!(result.contains("&lt;script"));
         assert!(!result.contains("<script language"));
     }
-}
 
+    #[test]
+    fn test_filter_values_are_safe_in_onclick_attributes() {
+        let finding = LogEvent {
+            timestamp: Utc::now(),
+            level: "alert".to_string(),
+            event_type: "file_match".to_string(),
+            hostname: "host".to_string(),
+            message: "match".to_string(),
+            context: BTreeMap::new(),
+            file_path: Some("C:\\tmp\\bad');alert(1);//\n</script>.exe".to_string()),
+            pid: None,
+            process_name: None,
+            score: Some(90.0),
+            file_type: Some("Executable".to_string()),
+            file_size: None,
+            md5: Some("abc');alert(1);//".to_string()),
+            sha1: None,
+            sha256: None,
+            file_created: None,
+            file_modified: None,
+            file_accessed: None,
+            reasons: Some(vec![MatchReason {
+                message: "YARA match with rule rule');alert(1);//".to_string(),
+                score: 80,
+                description: None,
+                author: None,
+                reference: None,
+                matched_strings: None,
+            }]),
+            start_time: None,
+            run_time: None,
+            memory_bytes: None,
+            cpu_usage: None,
+            connection_count: None,
+            listening_ports: None,
+        };
+
+        let html = render_finding_card(&finding, 1);
+
+        assert!(!html.contains("filterValue('"));
+        assert!(!html.contains("');alert(1);//"));
+        assert!(html.contains("\\n&lt;/script&gt;.exe"));
+        assert!(html.contains("filterValue(&quot;"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ mod modules;
 
 use std::fs;
 use std::sync::Arc;
-use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use clap::Parser;
 use arrayvec::ArrayVec;
 use csv::ReaderBuilder;
@@ -612,7 +612,7 @@ fn initialize_c2_iocs(logger: &UnifiedLogger) -> Vec<C2IOC> {
 }
 
 // Check if a remote address matches any C2 IOC
-// Supports IP exact match, CIDR match, and domain substring match
+// Supports IP exact match and domain/subdomain match
 pub fn check_c2_match<'a>(remote_addr: &str, c2_iocs: &'a [C2IOC]) -> Option<&'a C2IOC> {
     let remote_lower = remote_addr.to_lowercase();
     
@@ -625,16 +625,28 @@ pub fn check_c2_match<'a>(remote_addr: &str, c2_iocs: &'a [C2IOC]) -> Option<&'a
             }
             // TODO: CIDR match (would need ipnet crate)
             // For now, we'll do exact match only
-        } else {
-            // For domains: check if remote ends with the IOC domain
+        } else if domain_matches_ioc(&remote_lower, &c2_ioc.server) {
+            // For domains: exact match or dot-boundary subdomain match
             // e.g., "dga1.evildomain.com" matches IOC "evildomain.com"
-            if remote_lower.ends_with(&c2_ioc.server) || remote_lower == c2_ioc.server {
-                return Some(c2_ioc);
-            }
+            return Some(c2_ioc);
         }
     }
     
     None
+}
+
+fn domain_matches_ioc(remote_addr: &str, c2_server: &str) -> bool {
+    let remote_domain = remote_addr.trim_end_matches('.');
+    let c2_domain = c2_server.trim_start_matches('.').trim_end_matches('.').to_lowercase();
+
+    if c2_domain.is_empty() {
+        return false;
+    }
+
+    remote_domain == c2_domain
+        || remote_domain
+            .strip_suffix(&c2_domain)
+            .is_some_and(|prefix| prefix.ends_with('.'))
 }
 
 // Simple IP address check (IPv4)
@@ -962,9 +974,10 @@ fn welcome_message() {
     println!("------------------------------------------------------------------------");
 }
 
-/// Lock file guard to prevent multiple Loki instances from running simultaneously
+/// Lock directory guard to prevent multiple Loki instances from running simultaneously
 struct LockFile {
     path: PathBuf,
+    created: bool,
 }
 
 impl LockFile {
@@ -972,9 +985,16 @@ impl LockFile {
     fn acquire() -> Option<Self> {
         let lock_path = Self::get_lock_path();
         
-        // Check if lock file exists and if the process is still running
+        // Check if lock directory exists and if the process is still running.
         if lock_path.exists() {
-            if let Ok(mut file) = fs::File::open(&lock_path) {
+            match fs::symlink_metadata(&lock_path) {
+                Ok(metadata) if metadata.file_type().is_dir() => {}
+                Ok(_) => return None,
+                Err(_) => return None,
+            }
+
+            let pid_path = lock_path.join("pid");
+            if let Ok(mut file) = fs::File::open(&pid_path) {
                 let mut pid_str = String::new();
                 if file.read_to_string(&mut pid_str).is_ok() {
                     if let Ok(pid) = pid_str.trim().parse::<u32>() {
@@ -984,25 +1004,33 @@ impl LockFile {
                     }
                 }
             }
-            // Stale lock file - remove it
-            let _ = fs::remove_file(&lock_path);
+            // Stale lock directory - remove it
+            let _ = fs::remove_dir_all(&lock_path);
         }
         
-        // Create new lock file with our PID
-        if let Ok(mut file) = fs::File::create(&lock_path) {
-            let pid = std::process::id();
-            if file.write_all(pid.to_string().as_bytes()).is_ok() {
-                return Some(LockFile { path: lock_path });
+        // Create a lock directory atomically. This avoids following attacker-controlled
+        // symlinks in a world-writable temp directory.
+        match fs::create_dir(&lock_path) {
+            Ok(()) => {
+                let pid_path = lock_path.join("pid");
+                let pid = std::process::id();
+                if fs::write(&pid_path, pid.to_string()).is_err() {
+                    let _ = fs::remove_dir_all(&lock_path);
+                    return Some(LockFile { path: lock_path, created: false });
+                }
+                Some(LockFile { path: lock_path, created: true })
             }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => None,
+            Err(_) => Some(LockFile { path: lock_path, created: false }),
         }
-        
-        // Failed to create lock file - allow running anyway (e.g., read-only filesystem)
-        Some(LockFile { path: lock_path })
     }
     
     fn get_lock_path() -> PathBuf {
-        let temp_dir = std::env::temp_dir();
-        temp_dir.join("loki-rs.lock")
+        Self::lock_path_for_temp_dir(&std::env::temp_dir())
+    }
+
+    fn lock_path_for_temp_dir(temp_dir: &Path) -> PathBuf {
+        temp_dir.join("loki-rs.lock.d")
     }
     
     #[cfg(unix)]
@@ -1032,8 +1060,10 @@ impl LockFile {
 
 impl Drop for LockFile {
     fn drop(&mut self) {
-        // Clean up lock file when the program exits
-        let _ = fs::remove_file(&self.path);
+        // Clean up lock directory when the program exits
+        if self.created {
+            let _ = fs::remove_dir_all(&self.path);
+        }
     }
 }
 
@@ -1723,10 +1753,35 @@ mod tests {
         }
 
         #[test]
+        fn test_c2_domain_suffix_requires_dot_boundary() {
+            let c2_iocs = create_test_c2_iocs();
+
+            assert!(check_c2_match("notevil.com", &c2_iocs).is_none());
+            assert!(check_c2_match("definitely-evil.com", &c2_iocs).is_none());
+        }
+
+        #[test]
         fn test_c2_case_insensitive() {
             let c2_iocs = create_test_c2_iocs();
             let result = check_c2_match("EVIL.COM", &c2_iocs);
             assert!(result.is_some());
+        }
+
+        #[test]
+        fn test_c2_trailing_dot_match() {
+            let c2_iocs = create_test_c2_iocs();
+            let result = check_c2_match("dga.evil.com.", &c2_iocs);
+            assert!(result.is_some());
+        }
+    }
+
+    mod lock_file_tests {
+        use super::*;
+
+        #[test]
+        fn test_lock_uses_private_directory_name() {
+            let lock_path = LockFile::lock_path_for_temp_dir(Path::new("/tmp"));
+            assert_eq!(lock_path, Path::new("/tmp").join("loki-rs.lock.d"));
         }
     }
 

--- a/src/modules/filesystem_scan.rs
+++ b/src/modules/filesystem_scan.rs
@@ -17,6 +17,9 @@ use yara_x::{Scanner, Rules};
 use rayon::prelude::*;
 use zip::ZipArchive;
 
+const MAX_ARCHIVE_ENTRIES: usize = 10_000;
+const MAX_ARCHIVE_TOTAL_UNCOMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
+
 #[cfg(windows)]
 use windows::core::{PCWSTR, HSTRING};
 #[cfg(windows)]
@@ -790,24 +793,59 @@ fn process_file_entry(
 
         match ZipArchive::new(Cursor::new(&mmap)) {
             Ok(mut archive) => {
+                let mut archive_entries_scanned = 0usize;
+                let mut archive_bytes_scanned = 0u64;
+
                 for i in 0..archive.len() {
                     if let Ok(mut zfile) = archive.by_index(i) {
-                        if zfile.is_file() && zfile.size() < scan_config.max_file_size as u64 {
-                            let mut buffer = Vec::with_capacity(zfile.size() as usize);
-                            if zfile.read_to_end(&mut buffer).is_ok() {
-                                let entry_name = zfile.name().to_string();
-                                let display_path = format!("{}->{}", file_path_str, entry_name);
-                                let ext = Path::new(&entry_name).extension().map(|e| e.to_string_lossy()).unwrap_or_default();
-                                
-                                let (s, m, a, w, n) = scan_memory_buffer(
-                                    &buffer, &display_path, &entry_name, &ext, "ARCHIVE_ENTRY",
-                                    (0, 0, 0), // Timestamps inside zip? zfile.last_modified()
-                                    compiled_rules, scan_config, hash_collections, fp_hash_collections, filename_iocs,
-                                    logger, scan_state, 
-                                    Some(&container_info), Some(&file_path_str)
-                                );
-                                files_scanned += s; files_matched += m; alert_count += a; warning_count += w; notice_count += n;
+                        if !zfile.is_file() {
+                            continue;
+                        }
+
+                        match archive_entry_scan_decision(
+                            zfile.size(),
+                            archive_entries_scanned,
+                            archive_bytes_scanned,
+                            scan_config.max_file_size as u64,
+                        ) {
+                            ArchiveEntryScanDecision::Scan => {}
+                            ArchiveEntryScanDecision::SkipOversized => continue,
+                            ArchiveEntryScanDecision::StopEntryLimit => {
+                                logger.warning(&format!(
+                                    "Stopping ZIP archive scan after {} entries: {}",
+                                    archive_entries_scanned,
+                                    file_path_str
+                                ));
+                                break;
                             }
+                            ArchiveEntryScanDecision::StopTotalSizeLimit => {
+                                logger.warning(&format!(
+                                    "Stopping ZIP archive scan after {} uncompressed bytes: {}",
+                                    archive_bytes_scanned,
+                                    file_path_str
+                                ));
+                                break;
+                            }
+                        }
+
+                        let entry_size = zfile.size();
+                        let mut buffer = Vec::with_capacity(entry_size as usize);
+                        if zfile.read_to_end(&mut buffer).is_ok() {
+                            archive_entries_scanned += 1;
+                            archive_bytes_scanned = archive_bytes_scanned.saturating_add(buffer.len() as u64);
+
+                            let entry_name = zfile.name().to_string();
+                            let display_path = format!("{}->{}", file_path_str, entry_name);
+                            let ext = Path::new(&entry_name).extension().map(|e| e.to_string_lossy()).unwrap_or_default();
+
+                            let (s, m, a, w, n) = scan_memory_buffer(
+                                &buffer, &display_path, &entry_name, &ext, "ARCHIVE_ENTRY",
+                                (0, 0, 0), // Timestamps inside zip? zfile.last_modified()
+                                compiled_rules, scan_config, hash_collections, fp_hash_collections, filename_iocs,
+                                logger, scan_state,
+                                Some(&container_info), Some(&file_path_str)
+                            );
+                            files_scanned += s; files_matched += m; alert_count += a; warning_count += w; notice_count += n;
                         }
                     }
                 }
@@ -818,6 +856,35 @@ fn process_file_entry(
 
     if let Some(state) = scan_state { state.clear_current_element(); }
     (files_scanned, files_matched, alert_count, warning_count, notice_count)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ArchiveEntryScanDecision {
+    Scan,
+    SkipOversized,
+    StopEntryLimit,
+    StopTotalSizeLimit,
+}
+
+fn archive_entry_scan_decision(
+    entry_size: u64,
+    entries_scanned: usize,
+    bytes_scanned: u64,
+    max_file_size: u64,
+) -> ArchiveEntryScanDecision {
+    if entries_scanned >= MAX_ARCHIVE_ENTRIES {
+        return ArchiveEntryScanDecision::StopEntryLimit;
+    }
+
+    if entry_size > max_file_size {
+        return ArchiveEntryScanDecision::SkipOversized;
+    }
+
+    if bytes_scanned.saturating_add(entry_size) > MAX_ARCHIVE_TOTAL_UNCOMPRESSED_BYTES {
+        return ArchiveEntryScanDecision::StopTotalSizeLimit;
+    }
+
+    ArchiveEntryScanDecision::Scan
 }
 
 fn scan_memory_buffer(
@@ -1338,6 +1405,47 @@ mod tests {
             assert_eq!(info.md5.len(), 32);
             assert_eq!(info.sha1.len(), 40);
             assert_eq!(info.sha256.len(), 64);
+        }
+    }
+
+    mod archive_limit_tests {
+        use super::*;
+
+        #[test]
+        fn test_archive_entry_scan_decision_allows_normal_entry() {
+            assert_eq!(
+                archive_entry_scan_decision(1024, 0, 0, 10 * 1024),
+                ArchiveEntryScanDecision::Scan
+            );
+        }
+
+        #[test]
+        fn test_archive_entry_scan_decision_skips_oversized_entry() {
+            assert_eq!(
+                archive_entry_scan_decision(20 * 1024, 0, 0, 10 * 1024),
+                ArchiveEntryScanDecision::SkipOversized
+            );
+        }
+
+        #[test]
+        fn test_archive_entry_scan_decision_stops_on_entry_limit() {
+            assert_eq!(
+                archive_entry_scan_decision(1024, MAX_ARCHIVE_ENTRIES, 0, 10 * 1024),
+                ArchiveEntryScanDecision::StopEntryLimit
+            );
+        }
+
+        #[test]
+        fn test_archive_entry_scan_decision_stops_on_total_size_limit() {
+            assert_eq!(
+                archive_entry_scan_decision(
+                    2,
+                    0,
+                    MAX_ARCHIVE_TOTAL_UNCOMPRESSED_BYTES,
+                    10 * 1024
+                ),
+                ArchiveEntryScanDecision::StopTotalSizeLimit
+            );
         }
     }
 

--- a/src/modules/filesystem_scan.rs
+++ b/src/modules/filesystem_scan.rs
@@ -828,12 +828,15 @@ fn process_file_entry(
                             }
                         }
 
+                        // Count the entry and reserve its uncompressed-size budget *before*
+                        // attempting read_to_end, so a malformed ZIP with many entries
+                        // that fail to read cannot bypass the entry-count / total-size limits.
                         let entry_size = zfile.size();
+                        archive_entries_scanned += 1;
+                        archive_bytes_scanned = archive_bytes_scanned.saturating_add(entry_size);
+
                         let mut buffer = Vec::with_capacity(entry_size as usize);
                         if zfile.read_to_end(&mut buffer).is_ok() {
-                            archive_entries_scanned += 1;
-                            archive_bytes_scanned = archive_bytes_scanned.saturating_add(buffer.len() as u64);
-
                             let entry_name = zfile.name().to_string();
                             let display_path = format!("{}->{}", file_path_str, entry_name);
                             let ext = Path::new(&entry_name).extension().map(|e| e.to_string_lossy()).unwrap_or_default();

--- a/tests/configuration_tests/test_exclusion_count.sh
+++ b/tests/configuration_tests/test_exclusion_count.sh
@@ -23,6 +23,30 @@ cd "$PROJECT_ROOT"
 CONFIG_FILE="$PROJECT_ROOT/config/excludes.cfg"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
+CONFIG_EXISTED=false
+CONFIG_RESTORED=false
+
+restore_excludes_config() {
+    if [ "$CONFIG_RESTORED" = true ]; then
+        return
+    fi
+
+    if [ -f "${CONFIG_FILE}.test_backup" ]; then
+        mv "${CONFIG_FILE}.test_backup" "$CONFIG_FILE"
+    elif [ "$CONFIG_EXISTED" = false ]; then
+        rm -f "$CONFIG_FILE"
+    fi
+
+    CONFIG_RESTORED=true
+}
+
+# Restore config on exit (covers both backup-restore and temp-config removal)
+# Replaces the default cleanup trap from register_cleanup
+trap '{
+    restore_excludes_config
+    teardown_temp_dir
+}' EXIT
+
 section "Setup Test Environment"
 
 # Create a simple test directory
@@ -32,8 +56,8 @@ echo "test" > "$TEST_DIR/test.txt"
 
 # Backup original config
 if [ -f "$CONFIG_FILE" ]; then
+    CONFIG_EXISTED=true
     backup_file "$CONFIG_FILE"
-    ORIGINAL_CONFIG=$(cat "$CONFIG_FILE")
 fi
 
 section "Test 1: Empty exclusion config (0 exclusions)"
@@ -108,13 +132,8 @@ fi
 
 section "Cleanup: Restore original config"
 
-# Restore original config
-if [ -n "${ORIGINAL_CONFIG:-}" ]; then
-    echo "$ORIGINAL_CONFIG" > "$CONFIG_FILE"
-    echo "Restored original config"
-else
-    restore_file "$CONFIG_FILE"
-fi
+restore_excludes_config
+echo "Restored original config"
 
 section "Test Results"
 

--- a/tests/configuration_tests/test_exclusion_count.sh
+++ b/tests/configuration_tests/test_exclusion_count.sh
@@ -19,8 +19,9 @@ register_cleanup
 PROJECT_ROOT=$(get_project_root)
 cd "$PROJECT_ROOT"
 
-# Config file location
-CONFIG_FILE="$PROJECT_ROOT/build/config/excludes.cfg"
+# Config file location used by Loki at runtime
+CONFIG_FILE="$PROJECT_ROOT/config/excludes.cfg"
+mkdir -p "$(dirname "$CONFIG_FILE")"
 
 section "Setup Test Environment"
 
@@ -59,7 +60,7 @@ if echo "$TEST_OUTPUT" | grep -qiE "exclusion.*:.*0|0.*exclusion"; then
     echo "$TEST_OUTPUT" | grep -iE "exclusion" | head -3 | sed 's/^/    /'
 else
     echo "  Searching for exclusion info in output:"
-    echo "$TEST_OUTPUT" | grep -iE "(exclusion|config)" | head -5 | sed 's/^/    /'
+    echo "$TEST_OUTPUT" | grep -iE "(exclusion|config)" | head -5 | sed 's/^/    /' || true
 fi
 
 section "Test 2: Config with 3 exclusion patterns"
@@ -91,7 +92,7 @@ elif echo "$TEST_OUTPUT" | grep -qiE "exclusion.*:.*[1-9]|[1-9].*exclusion"; the
     echo "$TEST_OUTPUT" | grep -iE "exclusion" | head -3 | sed 's/^/    /'
 else
     echo "  Searching for exclusion info in output:"
-    echo "$TEST_OUTPUT" | grep -iE "(exclusion|config|pattern)" | head -5 | sed 's/^/    /'
+    echo "$TEST_OUTPUT" | grep -iE "(exclusion|config|pattern)" | head -5 | sed 's/^/    /' || true
 fi
 
 section "Test 3: Verify exclusion count is reported in scan info"
@@ -100,7 +101,7 @@ section "Test 3: Verify exclusion count is reported in scan info"
 if echo "$TEST_OUTPUT" | grep -qiE "(Configuration|Scan limits|Settings)"; then
     echo -e "${GREEN}✓ Configuration/settings section found${NC}"
     echo "  Relevant output:"
-    echo "$TEST_OUTPUT" | grep -iE "(configuration|limits|exclusion|setting)" | head -10 | sed 's/^/    /'
+    echo "$TEST_OUTPUT" | grep -iE "(configuration|limits|exclusion|setting)" | head -10 | sed 's/^/    /' || true
 else
     echo "  Output does not explicitly show configuration section"
 fi
@@ -125,4 +126,3 @@ else
     echo "=== Exclusion Count Test: FAIL ==="
     exit 1
 fi
-

--- a/tests/detection_tests/test_exclusions.sh
+++ b/tests/detection_tests/test_exclusions.sh
@@ -23,6 +23,30 @@ cd "$PROJECT_ROOT"
 CONFIG_FILE="$PROJECT_ROOT/config/excludes.cfg"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
+CONFIG_EXISTED=false
+CONFIG_RESTORED=false
+
+restore_excludes_config() {
+    if [ "$CONFIG_RESTORED" = true ]; then
+        return
+    fi
+
+    if [ -f "${CONFIG_FILE}.test_backup" ]; then
+        mv "${CONFIG_FILE}.test_backup" "$CONFIG_FILE"
+    elif [ "$CONFIG_EXISTED" = false ]; then
+        rm -f "$CONFIG_FILE"
+    fi
+
+    CONFIG_RESTORED=true
+}
+
+# Restore config on exit (covers both backup-restore and temp-config removal)
+# Replaces the default cleanup trap from register_cleanup
+trap '{
+    restore_excludes_config
+    teardown_temp_dir
+}' EXIT
+
 section "Setup Test Environment"
 
 # Create a test directory with a unique name we can exclude
@@ -36,10 +60,9 @@ echo "Created test file: $TEST_FILE"
 
 # Backup the original config
 if [ -f "$CONFIG_FILE" ]; then
+    CONFIG_EXISTED=true
     backup_file "$CONFIG_FILE"
-    ORIGINAL_CONFIG=$(cat "$CONFIG_FILE")
 else
-    ORIGINAL_CONFIG=""
     echo "# LOKI2 Exclusions Configuration" > "$CONFIG_FILE"
 fi
 
@@ -103,12 +126,7 @@ fi
 
 section "Cleanup: Restore original config"
 
-# Restore original config
-if [ -n "$ORIGINAL_CONFIG" ]; then
-    echo "$ORIGINAL_CONFIG" > "$CONFIG_FILE"
-else
-    restore_file "$CONFIG_FILE"
-fi
+restore_excludes_config
 echo "Config restored"
 
 section "Test Results"

--- a/tests/detection_tests/test_exclusions.sh
+++ b/tests/detection_tests/test_exclusions.sh
@@ -19,8 +19,9 @@ register_cleanup
 PROJECT_ROOT=$(get_project_root)
 cd "$PROJECT_ROOT"
 
-# Config file location
-CONFIG_FILE="$PROJECT_ROOT/build/config/excludes.cfg"
+# Config file location used by Loki at runtime
+CONFIG_FILE="$PROJECT_ROOT/config/excludes.cfg"
+mkdir -p "$(dirname "$CONFIG_FILE")"
 
 section "Setup Test Environment"
 
@@ -120,4 +121,3 @@ else
     echo "=== Exclusion Configuration Test: FAIL ==="
     exit 1
 fi
-


### PR DESCRIPTION
## Summary
- harden the single-instance lock by replacing the predictable temp lock file with an atomic lock directory
- tighten C2 IOC domain matching to require exact or dot-boundary subdomain matches
- escape HTML report filter values as JSON string literals before embedding them in onclick attributes
- add ZIP archive entry and aggregate uncompressed-size scan limits
- point exclusion integration tests at config/excludes.cfg, the file Loki reads at runtime, and make diagnostic greps pipefail-safe

## Validation
- cargo check
- cargo test -- --test-threads=1
- tests/detection_tests/test_exclusions.sh
- tests/configuration_tests/test_exclusion_count.sh

Note: clippy was not run here; the repo already has existing denied clippy lint debt from the prior review pass.