### PR TITLE
fix: make YARA scan timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sudo ./loki --remote syslog-host.internal:514 --remote-proto udp
 | `--notice-level <SCORE>` | `40` | Score threshold for NOTICE |
 | `--max-reasons <NUM>` | `2` | Max match reasons to display per finding |
 | `-m, --max-file-size <BYTES>` | `64000000` | Maximum file size to scan (64MB) |
-| `--yara-timeout <SECONDS>` | `10` | YARA scan timeout per file/process |
+| `--yara-timeout <SECONDS>` | `10` | Maximum YARA scan time for each file or process-memory buffer (minimum: 1 second) |
 | `-c, --cpu-limit <PERCENT>` | `100` | CPU utilization limit (1-100) |
 | `--threads <NUM>` | `-2` | Number of threads (0=all, -1=all-1, -2=all-2) |
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ sudo ./loki --remote syslog-host.internal:514 --remote-proto udp
 | `--notice-level <SCORE>` | `40` | Score threshold for NOTICE |
 | `--max-reasons <NUM>` | `2` | Max match reasons to display per finding |
 | `-m, --max-file-size <BYTES>` | `64000000` | Maximum file size to scan (64MB) |
+| `--yara-timeout <SECONDS>` | `10` | YARA scan timeout per file/process |
 | `-c, --cpu-limit <PERCENT>` | `100` | CPU utilization limit (1-100) |
 | `--threads <NUM>` | `-2` | Number of threads (0=all, -1=all-1, -2=all-2) |
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -33,7 +33,7 @@ Loki-RS - High-Performance, Multi-threaded YARA & IOC Scanner
 
 Options:
   -m, --max-file-size         Maximum file size to scan (default: 10000000)
-      --yara-timeout <SECONDS> YARA scan timeout per file/process in seconds (default: 10)
+      --yara-timeout <SECONDS> Maximum YARA scan time per file/process in seconds (default: 10)
   -s, --show-access-errors    Show all file and process access errors
   -c, --scan-all-files        Scan all files regardless of their file type / extension
   -d, --debug                 Show debugging information

--- a/USAGE.md
+++ b/USAGE.md
@@ -33,7 +33,7 @@ Loki-RS - High-Performance, Multi-threaded YARA & IOC Scanner
 
 Options:
   -m, --max-file-size         Maximum file size to scan (default: 10000000)
-      --yara-timeout          YARA scan timeout per file/process in seconds (default: 10)
+      --yara-timeout <SECONDS> YARA scan timeout per file/process in seconds (default: 10)
   -s, --show-access-errors    Show all file and process access errors
   -c, --scan-all-files        Scan all files regardless of their file type / extension
   -d, --debug                 Show debugging information

--- a/USAGE.md
+++ b/USAGE.md
@@ -33,6 +33,7 @@ Loki-RS - High-Performance, Multi-threaded YARA & IOC Scanner
 
 Options:
   -m, --max-file-size         Maximum file size to scan (default: 10000000)
+      --yara-timeout          YARA scan timeout per file/process in seconds (default: 10)
   -s, --show-access-errors    Show all file and process access errors
   -c, --scan-all-files        Scan all files regardless of their file type / extension
   -d, --debug                 Show debugging information

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -5,3 +5,4 @@ pub mod throttler;
 pub mod interrupt;
 pub mod tui;
 pub mod unified_logger;
+pub mod yara;

--- a/src/helpers/html_report.rs
+++ b/src/helpers/html_report.rs
@@ -2244,5 +2244,23 @@ mod tests {
         assert!(result.contains("&lt;script"));
         assert!(!result.contains("<script language"));
     }
-}
 
+    #[test]
+    fn test_operational_yara_timeout_is_not_reported_as_finding() {
+        let path = std::env::temp_dir().join(format!(
+            "loki-yara-timeout-error-{}.jsonl",
+            std::process::id()
+        ));
+        let jsonl = r#"{"timestamp":"2026-06-18T09:09:29Z","level":"ERROR","event_type":"error","hostname":"host","message":"YARA scan timeout while scanning FILE: sample.bin - skipping and continuing","context":{"FILE":"sample.bin"}}"#;
+
+        std::fs::write(&path, jsonl).expect("write jsonl fixture");
+        let report_data = parse_jsonl(path.to_str().expect("temp path is valid UTF-8"))
+            .expect("parse jsonl fixture");
+        let html = render_findings(&report_data.findings);
+        let _ = std::fs::remove_file(&path);
+
+        assert!(report_data.findings.is_empty());
+        assert!(html.contains("No Findings"));
+        assert!(!html.contains("YARA scan timeout"));
+    }
+}

--- a/src/helpers/html_report.rs
+++ b/src/helpers/html_report.rs
@@ -86,8 +86,10 @@ pub fn generate_report(jsonl_path: &str, scan_config: &ScanConfig, version: &str
 pub fn parse_jsonl(path: &str) -> Result<ReportData, String> {
     let file = File::open(path)
         .map_err(|e| format!("Failed to open JSONL file: {}", e))?;
-    let reader = BufReader::new(file);
-    
+    parse_jsonl_reader(BufReader::new(file))
+}
+
+fn parse_jsonl_reader<R: BufRead>(reader: R) -> Result<ReportData, String> {
     let mut scan_start = None;
     let mut scan_end = None;
     let mut info_events = Vec::new();
@@ -2247,17 +2249,10 @@ mod tests {
 
     #[test]
     fn test_operational_yara_timeout_is_not_reported_as_finding() {
-        let path = std::env::temp_dir().join(format!(
-            "loki-yara-timeout-error-{}.jsonl",
-            std::process::id()
-        ));
-        let jsonl = r#"{"timestamp":"2026-06-18T09:09:29Z","level":"ERROR","event_type":"error","hostname":"host","message":"YARA scan timeout while scanning FILE: sample.bin - skipping and continuing","context":{"FILE":"sample.bin"}}"#;
-
-        std::fs::write(&path, jsonl).expect("write jsonl fixture");
-        let report_data = parse_jsonl(path.to_str().expect("temp path is valid UTF-8"))
-            .expect("parse jsonl fixture");
+        let jsonl = r#"{"timestamp":"2026-06-18T09:09:29Z","level":"ERROR","event_type":"error","hostname":"host","message":"YARA scan timeout while scanning FILE: sample.bin - skipping and continuing","file_path":"sample.bin"}"#;
+        let report_data = parse_jsonl_reader(std::io::Cursor::new(jsonl))
+            .expect("parse in-memory JSONL fixture");
         let html = render_findings(&report_data.findings);
-        let _ = std::fs::remove_file(&path);
 
         assert!(report_data.findings.is_empty());
         assert!(html.contains("No Findings"));

--- a/src/helpers/unified_logger.rs
+++ b/src/helpers/unified_logger.rs
@@ -792,14 +792,45 @@ impl UnifiedLogger {
             context_map.insert(k.to_string(), v.to_string());
         }
 
+        self.error_with_target(msg, context_map, None, None, None);
+    }
+
+    pub fn file_error(&self, msg: &str, path: &str) {
+        self.error_with_target(
+            msg,
+            BTreeMap::new(),
+            Some(path.to_string()),
+            None,
+            None,
+        );
+    }
+
+    pub fn process_error(&self, msg: &str, pid: u32, process_name: &str) {
+        self.error_with_target(
+            msg,
+            BTreeMap::new(),
+            None,
+            Some(pid),
+            Some(process_name.to_string()),
+        );
+    }
+
+    fn error_with_target(
+        &self,
+        msg: &str,
+        context: BTreeMap<String, String>,
+        file_path: Option<String>,
+        pid: Option<u32>,
+        process_name: Option<String>,
+    ) {
         self.log(LogEvent {
             timestamp: Utc::now(),
             level: LogLevel::Error,
             event_type: EventType::Error,
             hostname: self.hostname.clone(),
             message: msg.to_string(),
-            context: context_map,
-            file_path: None, pid: None, process_name: None, score: None,
+            context,
+            file_path, pid, process_name, score: None,
             file_type: None, file_size: None, md5: None, sha1: None, sha256: None, reasons: None,
             file_created: None, file_modified: None, file_accessed: None,
             start_time: None, run_time: None, memory_bytes: None, cpu_usage: None, connection_count: None, listening_ports: None,

--- a/src/helpers/yara.rs
+++ b/src/helpers/yara.rs
@@ -1,0 +1,169 @@
+use yara_x::ScanError;
+
+use crate::helpers::unified_logger::UnifiedLogger;
+
+#[derive(Clone, Copy, Debug)]
+pub enum YaraScanTarget<'a> {
+    File(&'a str),
+    Process { pid: u32, process_name: &'a str },
+}
+
+/// Log YARA scan failures consistently without turning operational failures
+/// into detection findings.
+pub fn log_yara_scan_error(
+    logger: &UnifiedLogger,
+    error: &ScanError,
+    target: YaraScanTarget<'_>,
+    report_non_timeout_errors: bool,
+) {
+    let is_timeout = matches!(error, ScanError::Timeout);
+
+    match target {
+        YaraScanTarget::File(path) => {
+            let message = if is_timeout {
+                format!(
+                    "YARA scan timeout while scanning FILE: {} - skipping and continuing",
+                    path
+                )
+            } else {
+                format!("YARA-X scan error FILE: {} ERROR: {}", path, error)
+            };
+
+            if is_timeout || report_non_timeout_errors {
+                logger.file_error(&message, path);
+            } else {
+                logger.debug(&message);
+            }
+        }
+        YaraScanTarget::Process { pid, process_name } => {
+            let message = if is_timeout {
+                format!(
+                    "YARA scan timeout while scanning process memory PID: {} PROC_NAME: {} - skipping and continuing",
+                    pid, process_name
+                )
+            } else {
+                format!(
+                    "YARA-X process-memory scan error PID: {} PROC_NAME: {} ERROR: {}",
+                    pid, process_name, error
+                )
+            };
+
+            if is_timeout || report_non_timeout_errors {
+                logger.process_error(&message, pid, process_name);
+            } else {
+                logger.debug(&message);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helpers::unified_logger::{
+        EventType, LogLevel, LoggerConfig, TuiMessage, UnifiedLogger,
+    };
+    use std::sync::mpsc::{self, Receiver};
+
+    fn test_logger() -> (UnifiedLogger, Receiver<TuiMessage>) {
+        let (sender, receiver) = mpsc::channel();
+        let logger = UnifiedLogger::new(LoggerConfig {
+            console: false,
+            log_level: LogLevel::Debug,
+            log_file: None,
+            jsonl_file: None,
+            remote: None,
+            tui_sender: Some(sender),
+        })
+        .expect("create test logger");
+        (logger, receiver)
+    }
+
+    fn receive_event(receiver: &Receiver<TuiMessage>) -> crate::helpers::unified_logger::LogEvent {
+        match receiver.recv().expect("receive log event") {
+            TuiMessage::Log(event) => event,
+            message => panic!("expected log event, got {:?}", message),
+        }
+    }
+
+    #[test]
+    fn file_timeout_is_a_structured_operational_error() {
+        let (logger, receiver) = test_logger();
+
+        log_yara_scan_error(
+            &logger,
+            &ScanError::Timeout,
+            YaraScanTarget::File("sample.bin"),
+            false,
+        );
+
+        let event = receive_event(&receiver);
+        assert_eq!(event.level, LogLevel::Error);
+        assert_eq!(event.event_type, EventType::Error);
+        assert_eq!(event.file_path.as_deref(), Some("sample.bin"));
+        assert!(event.pid.is_none());
+        assert!(event.message.contains("YARA scan timeout"));
+    }
+
+    #[test]
+    fn process_timeout_is_a_structured_operational_error() {
+        let (logger, receiver) = test_logger();
+
+        log_yara_scan_error(
+            &logger,
+            &ScanError::Timeout,
+            YaraScanTarget::Process {
+                pid: 42,
+                process_name: "sample",
+            },
+            false,
+        );
+
+        let event = receive_event(&receiver);
+        assert_eq!(event.level, LogLevel::Error);
+        assert_eq!(event.event_type, EventType::Error);
+        assert_eq!(event.pid, Some(42));
+        assert_eq!(event.process_name.as_deref(), Some("sample"));
+        assert!(event.file_path.is_none());
+        assert!(event.message.contains("YARA scan timeout"));
+    }
+
+    #[test]
+    fn non_timeout_scan_errors_are_debug_only_by_default() {
+        let (logger, receiver) = test_logger();
+        let error = ScanError::UnknownModule {
+            module: "test".to_string(),
+        };
+
+        log_yara_scan_error(&logger, &error, YaraScanTarget::File("sample.bin"), false);
+
+        let event = receive_event(&receiver);
+        assert_eq!(event.level, LogLevel::Debug);
+        assert_eq!(event.event_type, EventType::Info);
+        assert!(event.message.contains("unknown module"));
+    }
+
+    #[test]
+    fn verbose_scan_errors_are_structured_errors() {
+        let (logger, receiver) = test_logger();
+        let error = ScanError::UnknownModule {
+            module: "test".to_string(),
+        };
+
+        log_yara_scan_error(
+            &logger,
+            &error,
+            YaraScanTarget::Process {
+                pid: 42,
+                process_name: "sample",
+            },
+            true,
+        );
+
+        let event = receive_event(&receiver);
+        assert_eq!(event.level, LogLevel::Error);
+        assert_eq!(event.event_type, EventType::Error);
+        assert_eq!(event.pid, Some(42));
+        assert_eq!(event.process_name.as_deref(), Some("sample"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,15 @@ struct Cli {
     #[arg(short = 'm', long, default_value_t = 64_000_000, help_heading = "Tuning")]
     max_file_size: usize,
 
+    /// YARA scan timeout per file/process in seconds
+    #[arg(
+        long,
+        default_value_t = 10,
+        value_parser = clap::value_parser!(u64).range(1..),
+        help_heading = "Tuning"
+    )]
+    yara_timeout: u64,
+
     /// CPU utilization limit percentage (1-100)
     #[arg(short = 'c', long, default_value_t = 100, help_heading = "Tuning")]
     cpu_limit: u8,
@@ -197,6 +206,7 @@ pub struct ScanConfig {
     pub warning_threshold: i16,
     pub notice_threshold: i16,
     pub max_reasons: usize,
+    pub yara_timeout: u64,
     pub threads: usize,
     pub cpu_limit: u8,
     pub exclusion_count: usize,
@@ -1244,6 +1254,7 @@ fn main() {
         warning_threshold: args.warning_level,
         notice_threshold: args.notice_level,
         max_reasons: args.max_reasons,
+        yara_timeout: args.yara_timeout,
         threads: num_threads,
         cpu_limit: args.cpu_limit,
         exclusion_count,
@@ -1295,6 +1306,7 @@ fn main() {
     // Print scan configuration limits
     logger.info_w("Scan limits", &[
         ("MAX_FILE_SIZE", &format!("{} bytes ({:.1} MB)", scan_config.max_file_size, scan_config.max_file_size as f64 / 1_000_000.0)),
+        ("YARA_TIMEOUT", &format!("{} seconds", scan_config.yara_timeout)),
     ]);
     logger.info_w("Scan limits", &[
         ("SCAN_ALL_TYPES", &scan_config.scan_all_types.to_string()),
@@ -1955,6 +1967,7 @@ mod tests {
                 warning_threshold: 60,
                 notice_threshold: 40,
                 max_reasons: 2,
+                yara_timeout: 10,
                 threads: 4,
                 cpu_limit: 100,
                 exclusion_count: 0,
@@ -1984,6 +1997,7 @@ mod tests {
                 warning_threshold: 60,
                 notice_threshold: 40,
                 max_reasons: 2,
+                yara_timeout: 10,
                 threads: 4,
                 cpu_limit: 100,
                 exclusion_count: 0,
@@ -2653,6 +2667,7 @@ mod tests {
                 warning_threshold: 60,
                 notice_threshold: 40,
                 max_reasons: 2,
+                yara_timeout: 10,
                 threads: 4,
                 cpu_limit: 100,
                 exclusion_count: 0,
@@ -3305,6 +3320,7 @@ mod tests {
                 warning_threshold: 60,
                 notice_threshold: 40,
                 max_reasons: 2,
+                yara_timeout: 10,
                 threads: 4,
                 cpu_limit: 100,
                 exclusion_count: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,10 +115,11 @@ struct Cli {
     #[arg(short = 'm', long, default_value_t = 64_000_000, help_heading = "Tuning")]
     max_file_size: usize,
 
-    /// YARA scan timeout per file/process in seconds
+    /// Maximum YARA scan time for each file or process-memory buffer, in seconds
     #[arg(
         long,
         default_value_t = 10,
+        value_name = "SECONDS",
         value_parser = clap::value_parser!(u64).range(1..),
         help_heading = "Tuning"
     )]
@@ -206,7 +207,7 @@ pub struct ScanConfig {
     pub warning_threshold: i16,
     pub notice_threshold: i16,
     pub max_reasons: usize,
-    pub yara_timeout: u64,
+    pub yara_timeout: std::time::Duration,
     pub threads: usize,
     pub cpu_limit: u8,
     pub exclusion_count: usize,
@@ -1254,7 +1255,7 @@ fn main() {
         warning_threshold: args.warning_level,
         notice_threshold: args.notice_level,
         max_reasons: args.max_reasons,
-        yara_timeout: args.yara_timeout,
+        yara_timeout: std::time::Duration::from_secs(args.yara_timeout),
         threads: num_threads,
         cpu_limit: args.cpu_limit,
         exclusion_count,
@@ -1306,7 +1307,7 @@ fn main() {
     // Print scan configuration limits
     logger.info_w("Scan limits", &[
         ("MAX_FILE_SIZE", &format!("{} bytes ({:.1} MB)", scan_config.max_file_size, scan_config.max_file_size as f64 / 1_000_000.0)),
-        ("YARA_TIMEOUT", &format!("{} seconds", scan_config.yara_timeout)),
+        ("YARA_TIMEOUT", &format!("{} seconds", scan_config.yara_timeout.as_secs())),
     ]);
     logger.info_w("Scan limits", &[
         ("SCAN_ALL_TYPES", &scan_config.scan_all_types.to_string()),
@@ -1950,6 +1951,28 @@ mod tests {
         }
     }
 
+    mod cli_yara_timeout_tests {
+        use super::*;
+
+        #[test]
+        fn defaults_to_ten_seconds() {
+            let args = Cli::try_parse_from(["loki"]).expect("parse default arguments");
+            assert_eq!(args.yara_timeout, 10);
+        }
+
+        #[test]
+        fn accepts_a_positive_timeout() {
+            let args = Cli::try_parse_from(["loki", "--yara-timeout", "30"])
+                .expect("parse positive YARA timeout");
+            assert_eq!(args.yara_timeout, 30);
+        }
+
+        #[test]
+        fn rejects_a_zero_timeout() {
+            assert!(Cli::try_parse_from(["loki", "--yara-timeout", "0"]).is_err());
+        }
+    }
+
     mod scan_config_tests {
         use super::*;
 
@@ -1967,7 +1990,7 @@ mod tests {
                 warning_threshold: 60,
                 notice_threshold: 40,
                 max_reasons: 2,
-                yara_timeout: 10,
+                yara_timeout: std::time::Duration::from_secs(10),
                 threads: 4,
                 cpu_limit: 100,
                 exclusion_count: 0,
@@ -1997,7 +2020,7 @@ mod tests {
                 warning_threshold: 60,
                 notice_threshold: 40,
                 max_reasons: 2,
-                yara_timeout: 10,
+                yara_timeout: std::time::Duration::from_secs(10),
                 threads: 4,
                 cpu_limit: 100,
                 exclusion_count: 0,
@@ -2667,7 +2690,7 @@ mod tests {
                 warning_threshold: 60,
                 notice_threshold: 40,
                 max_reasons: 2,
-                yara_timeout: 10,
+                yara_timeout: std::time::Duration::from_secs(10),
                 threads: 4,
                 cpu_limit: 100,
                 exclusion_count: 0,
@@ -3320,7 +3343,7 @@ mod tests {
                 warning_threshold: 60,
                 notice_threshold: 40,
                 max_reasons: 2,
-                yara_timeout: 10,
+                yara_timeout: std::time::Duration::from_secs(10),
                 threads: 4,
                 cpu_limit: 100,
                 exclusion_count: 0,

--- a/src/modules/filesystem_scan.rs
+++ b/src/modules/filesystem_scan.rs
@@ -44,6 +44,7 @@ use crate::helpers::unified_logger::{UnifiedLogger, MatchReason, LogLevel};
 use crate::helpers::throttler::{throttle_start, throttle_end_with_limit};
 use crate::helpers::helpers::log_access_error;
 use crate::helpers::interrupt::ScanState;
+use crate::helpers::yara::{log_yara_scan_error, YaraScanTarget};
 
 const REL_EXTS: &'static [&'static str] = &[".exe", ".dll", ".bat", ".ps1", ".asp", ".aspx", ".jsp", ".jspx", 
     ".php", ".plist", ".sh", ".vbs", ".js", ".dmp", ".py", ".msix"];
@@ -945,14 +946,18 @@ fn scan_memory_buffer(
         owner: "".to_string(),
     };
     
-    let (yara_matches, yara_timed_out) = scan_file(compiled_rules, content, scan_config, &ext_vars, path_display, logger);
-    if yara_timed_out {
-        let message = format!(
-            "YARA scan timeout while scanning FILE: {} - skipping and continuing",
-            path_display
-        );
-        logger.error_w(&message, &[("FILE", path_display)]);
-    }
+    let yara_matches = match scan_file(compiled_rules, content, scan_config, &ext_vars) {
+        Ok(matches) => matches,
+        Err(error) => {
+            log_yara_scan_error(
+                logger,
+                &error,
+                YaraScanTarget::File(path_display),
+                scan_config.show_access_errors,
+            );
+            ArrayVec::new()
+        }
+    };
     for ymatch in yara_matches.iter() {
         if !sample_matches.is_full() {
             let match_message = format!("YARA match with rule {}", ymatch.rulename);
@@ -1043,13 +1048,11 @@ fn scan_file(
     file_content: &[u8],
     scan_config: &ScanConfig,
     ext_vars: &ExtVars,
-    file_label: &str,
-    logger: &UnifiedLogger,
-) -> (ArrayVec<YaraMatch, 100>, bool) {
+) -> Result<ArrayVec<YaraMatch, 100>, yara_x::ScanError> {
     // YARA-X: Create scanner from rules
     let mut scanner = Scanner::new(rules);
     
-    scanner.set_timeout(std::time::Duration::from_secs(scan_config.yara_timeout));
+    scanner.set_timeout(scan_config.yara_timeout);
     
     // Define external variables (global variables in YARA-X)
     // YARA-X accepts strings directly for set_global
@@ -1074,7 +1077,6 @@ fn scan_file(
     
     // Handle scan results
     let mut yara_matches = ArrayVec::<YaraMatch, 100>::new();
-    let mut timed_out = false;
     match results {
         Ok(scan_results) => {
             // YARA-X: Use matching_rules() to iterate over results
@@ -1157,18 +1159,9 @@ fn scan_file(
                 }
             }
         },
-        Err(e) => {
-            let err_text = format!("{:?}", e);
-            if err_text.to_lowercase().contains("timeout") {
-                timed_out = true;
-            } else if scan_config.show_access_errors {
-                logger.error(&format!("YARA-X scan error FILE: {} ERROR: {:?}", file_label, e));
-            } else {
-                logger.debug(&format!("YARA-X scan error FILE: {} ERROR: {:?}", file_label, e));
-            }
-        }
+        Err(error) => return Err(error),
     }
-    (yara_matches, timed_out)
+    Ok(yara_matches)
 }
 
 #[cfg(test)]

--- a/src/modules/filesystem_scan.rs
+++ b/src/modules/filesystem_scan.rs
@@ -945,7 +945,14 @@ fn scan_memory_buffer(
         owner: "".to_string(),
     };
     
-    let yara_matches = scan_file(compiled_rules, content, scan_config, &ext_vars, path_display, logger);
+    let (yara_matches, yara_timed_out) = scan_file(compiled_rules, content, scan_config, &ext_vars, path_display, logger);
+    if yara_timed_out {
+        let message = format!(
+            "YARA scan timeout while scanning FILE: {} - skipping and continuing",
+            path_display
+        );
+        logger.error_w(&message, &[("FILE", path_display)]);
+    }
     for ymatch in yara_matches.iter() {
         if !sample_matches.is_full() {
             let match_message = format!("YARA match with rule {}", ymatch.rulename);
@@ -1038,12 +1045,11 @@ fn scan_file(
     ext_vars: &ExtVars,
     file_label: &str,
     logger: &UnifiedLogger,
-) -> ArrayVec<YaraMatch, 100> {
+) -> (ArrayVec<YaraMatch, 100>, bool) {
     // YARA-X: Create scanner from rules
     let mut scanner = Scanner::new(rules);
     
-    // Set timeout (in seconds)
-    scanner.set_timeout(std::time::Duration::from_secs(10));
+    scanner.set_timeout(std::time::Duration::from_secs(scan_config.yara_timeout));
     
     // Define external variables (global variables in YARA-X)
     // YARA-X accepts strings directly for set_global
@@ -1068,6 +1074,7 @@ fn scan_file(
     
     // Handle scan results
     let mut yara_matches = ArrayVec::<YaraMatch, 100>::new();
+    let mut timed_out = false;
     match results {
         Ok(scan_results) => {
             // YARA-X: Use matching_rules() to iterate over results
@@ -1153,10 +1160,7 @@ fn scan_file(
         Err(e) => {
             let err_text = format!("{:?}", e);
             if err_text.to_lowercase().contains("timeout") {
-                logger.warning(&format!(
-                    "YARA scan timeout while scanning FILE: {} - skipping and continuing",
-                    file_label
-                ));
+                timed_out = true;
             } else if scan_config.show_access_errors {
                 logger.error(&format!("YARA-X scan error FILE: {} ERROR: {:?}", file_label, e));
             } else {
@@ -1164,7 +1168,7 @@ fn scan_file(
             }
         }
     }
-    return yara_matches;
+    (yara_matches, timed_out)
 }
 
 #[cfg(test)]

--- a/src/modules/process_check.rs
+++ b/src/modules/process_check.rs
@@ -60,6 +60,7 @@ use crate::helpers::score::calculate_weighted_score;
 use crate::helpers::unified_logger::{UnifiedLogger, MatchReason, LogLevel};
 use crate::helpers::throttler::{throttle_start, throttle_end_with_limit};
 use crate::helpers::interrupt::ScanState;
+use crate::helpers::yara::{log_yara_scan_error, YaraScanTarget};
 
 use crate::modules::{ScanModule, ScanContext, ModuleResult};
 
@@ -401,7 +402,7 @@ fn process_single_process(
     // 3. YARA scanning (Memory)
     // YARA-X: Create scanner and scan process memory
     let mut scanner = Scanner::new(compiled_rules);
-    scanner.set_timeout(std::time::Duration::from_secs(scan_config.yara_timeout));
+    scanner.set_timeout(scan_config.yara_timeout);
     
     // Read process memory
     #[cfg(target_os = "macos")]
@@ -438,21 +439,21 @@ fn process_single_process(
     #[cfg(not(target_os = "macos"))]
     let mem_data = read_process_memory(pid_u32);
 
-    #[cfg(target_os = "macos")]
-    let yara_status = if mem_stats.task_for_pid_kr != KERN_SUCCESS {
-        "denied"
-    } else if mem_data.is_empty() {
-        "skipped"
-    } else {
-        "scanned"
-    };
-    #[cfg(not(target_os = "macos"))]
-    let yara_status = if mem_data.is_empty() { "skipped" } else { "scanned" };
+    if mem_data.is_empty() {
+        #[cfg(target_os = "macos")]
+        let yara_status = if mem_stats.task_for_pid_kr != KERN_SUCCESS {
+            "denied"
+        } else {
+            "skipped"
+        };
+        #[cfg(not(target_os = "macos"))]
+        let yara_status = "skipped";
 
-    logger.info(&format!(
-        "Process YARA scan result PID={} PROC_NAME={} RESULT={}",
-        pid_u32, proc_name_str, yara_status
-    ));
+        logger.info(&format!(
+            "Process YARA scan result PID={} PROC_NAME={} RESULT={}",
+            pid_u32, proc_name_str, yara_status
+        ));
+    }
 
     #[cfg(target_os = "macos")]
     if mem_data.is_empty() {
@@ -465,82 +466,97 @@ fn process_single_process(
     }
 
     if !mem_data.is_empty() {
-        if let Ok(scan_results) = scanner.scan(&mem_data) {
-            logger.debug(&format!("YARA-X scan result for PID: {} PROC_NAME: {} RESULT: {:?}", pid_u32, proc_name_str, scan_results));
+        match scanner.scan(&mem_data) {
+            Ok(scan_results) => {
+                logger.info(&format!(
+                    "Process YARA scan result PID={} PROC_NAME={} RESULT=scanned",
+                    pid_u32, proc_name_str
+                ));
+                logger.debug(&format!("YARA-X scan result for PID: {} PROC_NAME: {} RESULT: {:?}", pid_u32, proc_name_str, scan_results));
             
-            for matching_rule in scan_results.matching_rules() {
-                if !proc_matches.is_full() {
-                    let rule_id = matching_rule.identifier().to_string();
-                    
-                    let mut description = String::new();
-                    let mut author = String::new();
-                    let mut reference = String::new();
-                    let mut score = 75;
-                    
-                    for (key, value) in matching_rule.metadata() {
-                        match key {
-                            "description" => {
-                                if let yara_x::MetaValue::String(s) = value {
-                                    description = s.to_string();
-                                }
-                            }
-                            "author" => {
-                                if let yara_x::MetaValue::String(s) = value {
-                                    author = s.to_string();
-                                }
-                            }
-                            "reference" => {
-                                if let yara_x::MetaValue::String(s) = value {
-                                    reference = s.to_string();
-                                }
-                            }
-                            "score" => {
-                                if let yara_x::MetaValue::Integer(i) = value {
-                                    let s = i as i16;
-                                    if s > 0 && s <= 100 {
-                                        score = s;
+                for matching_rule in scan_results.matching_rules() {
+                    if !proc_matches.is_full() {
+                        let rule_id = matching_rule.identifier().to_string();
+
+                        let mut description = String::new();
+                        let mut author = String::new();
+                        let mut reference = String::new();
+                        let mut score = 75;
+
+                        for (key, value) in matching_rule.metadata() {
+                            match key {
+                                "description" => {
+                                    if let yara_x::MetaValue::String(s) = value {
+                                        description = s.to_string();
                                     }
                                 }
-                            }
-                            _ => {}
-                        }
-                    }
-                    
-                    let mut matched_strings: Vec<String> = Vec::new();
-                    for pattern in matching_rule.patterns() {
-                        for pattern_match in pattern.matches() {
-                            let identifier = pattern.identifier();
-                            let offset = pattern_match.range().start;
-                            let data = pattern_match.data();
-                            
-                            let value_str = if data.iter().all(|&b: &_| b.is_ascii() && (b >= 32 || b == 9 || b == 10 || b == 13)) {
-                                match String::from_utf8(data.to_vec()) {
-                                    Ok(s) => format!("'{}'", s),
-                                    Err(_) => hex::encode(data)
+                                "author" => {
+                                    if let yara_x::MetaValue::String(s) = value {
+                                        author = s.to_string();
+                                    }
                                 }
-                            } else {
-                                hex::encode(data)
-                            };
-                            
-                            matched_strings.push(format!("{}: {} @ {}", identifier, value_str, offset));
+                                "reference" => {
+                                    if let yara_x::MetaValue::String(s) = value {
+                                        reference = s.to_string();
+                                    }
+                                }
+                                "score" => {
+                                    if let yara_x::MetaValue::Integer(i) = value {
+                                        let s = i as i16;
+                                        if s > 0 && s <= 100 {
+                                            score = s;
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
                         }
+
+                        let mut matched_strings: Vec<String> = Vec::new();
+                        for pattern in matching_rule.patterns() {
+                            for pattern_match in pattern.matches() {
+                                let identifier = pattern.identifier();
+                                let offset = pattern_match.range().start;
+                                let data = pattern_match.data();
+
+                                let value_str = if data.iter().all(|&b: &_| b.is_ascii() && (b >= 32 || b == 9 || b == 10 || b == 13)) {
+                                    match String::from_utf8(data.to_vec()) {
+                                        Ok(s) => format!("'{}'", s),
+                                        Err(_) => hex::encode(data)
+                                    }
+                                } else {
+                                    hex::encode(data)
+                                };
+
+                                matched_strings.push(format!("{}: {} @ {}", identifier, value_str, offset));
+                            }
+                        }
+
+                        let match_message = format!("YARA-X match with rule {}", rule_id);
+
+                        proc_matches.insert(
+                            proc_matches.len(),
+                            GenMatch {
+                                message: match_message,
+                                score,
+                                description: if description.is_empty() { None } else { Some(description) },
+                                author: if author.is_empty() { None } else { Some(author) },
+                                reference: if reference.is_empty() { None } else { Some(reference) },
+                                matched_strings: if matched_strings.is_empty() { None } else { Some(matched_strings) },
+                            }
+                        );
                     }
-                    
-                    let match_message = format!("YARA-X match with rule {}", rule_id);
-                    
-                    proc_matches.insert(
-                        proc_matches.len(), 
-                        GenMatch { 
-                            message: match_message, 
-                            score,
-                            description: if description.is_empty() { None } else { Some(description) },
-                            author: if author.is_empty() { None } else { Some(author) },
-                            reference: if reference.is_empty() { None } else { Some(reference) },
-                            matched_strings: if matched_strings.is_empty() { None } else { Some(matched_strings) },
-                        }
-                    );
                 }
-            }
+            },
+            Err(error) => log_yara_scan_error(
+                logger,
+                &error,
+                YaraScanTarget::Process {
+                    pid: pid_u32,
+                    process_name: &proc_name_str,
+                },
+                scan_config.show_access_errors,
+            ),
         }
     }
     

--- a/src/modules/process_check.rs
+++ b/src/modules/process_check.rs
@@ -401,7 +401,7 @@ fn process_single_process(
     // 3. YARA scanning (Memory)
     // YARA-X: Create scanner and scan process memory
     let mut scanner = Scanner::new(compiled_rules);
-    scanner.set_timeout(std::time::Duration::from_secs(30));
+    scanner.set_timeout(std::time::Duration::from_secs(scan_config.yara_timeout));
     
     // Read process memory
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- add `--yara-timeout <SECONDS>` with a 10-second default and reject zero
- represent the configured timeout as a duration and apply it consistently to file and process-memory scans
- handle typed YARA-X scan failures through one shared path instead of parsing error text
- record timeouts as structured operational ERROR events with file or process fields
- keep non-timeout scan failures at debug level unless `--show-access-errors` is enabled
- report process scans as successful only after YARA-X completes successfully
- keep operational errors out of detection counts and HTML findings
- document the option and its minimum value

## Testing
- `cargo build --bin loki`
- `cargo test` — 283 passed
- `target/debug/loki --help`
- `target/debug/loki --yara-timeout 0 --no-procs --no-fs` — rejected as expected