### PR TITLE
Feature: Add YARA Rule ROT47 Encoding/Decoding Support

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,3 +6,4 @@ pub mod interrupt;
 pub mod tui;
 pub mod unified_logger;
 pub mod yara;
+pub mod codec;

--- a/src/helpers/codec.rs
+++ b/src/helpers/codec.rs
@@ -1,0 +1,8 @@
+// Apply ROT47 encoding/decoding to a byte buffer.
+pub fn rot47(buf: &mut [u8]) {
+    for b in buf {
+        if (33..=126).contains(b) {
+            *b = 33 + ((*b - 33 + 94 - 47) % 94);
+        }
+    }
+}

--- a/src/loki_util/main.rs
+++ b/src/loki_util/main.rs
@@ -1,4 +1,6 @@
 mod html_report;
+#[path = "../helpers/codec.rs"]
+mod codec;
 
 use std::fs;
 use std::io;
@@ -687,14 +689,6 @@ fn expand_inputs(pattern: &str) -> Result<Vec<String>, Box<dyn std::error::Error
     Ok(files)
 }
 
-fn rot47(buf: &mut [u8]) {
-    for b in buf {
-        if (33..=126).contains(b) {
-            *b = 33 + ((*b - 33 + 94 - 47) % 94);
-        }
-    }
-}
-
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 
@@ -770,7 +764,7 @@ fn convert_rule_file(path: &Path, convert_type: &str) -> Result<(), Box<dyn std:
             break;
         }
 
-        rot47(&mut buffer[..n]);
+        codec::rot47(&mut buffer[..n]);
 
         writer.write_all(&buffer[..n])?;
     }

--- a/src/loki_util/main.rs
+++ b/src/loki_util/main.rs
@@ -733,7 +733,7 @@ fn encode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 
             match encode(&file) {
                 Err(e) => {
-                    log_warn(&format!("File {} failed to encode because {}", file.to_str().unwrap(), e));
+                    log_warn(&format!("File {} failed to encode because {}", file.display(), e));
                 }
                 _ => {}
             }
@@ -810,7 +810,7 @@ fn decode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 
             match decode(&file) {
                 Err(e) => {
-                    log_warn(&format!("File {} failed to decode because {}", file.to_str().unwrap(), e));
+                    log_warn(&format!("File {} failed to decode because {}", file.display(), e));
                 }
                 _ => {}
             }

--- a/src/loki_util/main.rs
+++ b/src/loki_util/main.rs
@@ -94,6 +94,26 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        "encode" => {
+            if args.len() != 3 {
+                log_error(&format!("Arguments error\nUsage: loki-util encode <file/dir>"));
+                std::process::exit(1);
+            }
+            if let Err(e) = encode(Path::new(&args[2])) {
+                log_error(&format!("File {} failed to encode because {}", &args[2], e));
+                std::process::exit(1);
+            }
+        }
+        "decode" => {
+            if args.len() != 3 {
+                log_error(&format!("Arguments error\nUsage: loki-util decode <file/dir>"));
+                std::process::exit(1);
+            }
+            if let Err(e) = decode(Path::new(&args[2])) {
+                log_error(&format!("File {} failed to decode because {}", &args[2], e));
+                std::process::exit(1);
+            }
+        }
         "--help" | "-h" => {
             print_usage();
         }
@@ -128,7 +148,13 @@ fn print_usage() {
     println!("Commands:");
     println!("  {}   - Update YARA rules (YARA-Forge Core)", "update".green());
     println!("  {}  - Update Loki-RS program and signatures", "upgrade".green());
-    println!("  {}    - Generate HTML report from JSONL file(s)", "html".green());
+    println!("  {}     - Generate HTML report from JSONL file(s)", "html".green());
+    println!("  {}   - Encode YARA rules to reduce AV false positives", "encode".green());
+    println!("  {}   - Decode YARA rules to back to its original form", "decode".green());
+    println!();
+    println!("Encoding and decoding:");
+    println!("  loki-util encode <file/dir>");
+    println!("  loki-util decode <file/dir>");
     println!();
     println!("HTML Report Generation:");
     println!("  loki-util html --input <file.jsonl> --output <report.html>");
@@ -138,7 +164,7 @@ fn print_usage() {
     println!("  --input <file|glob>  - Input JSONL file or glob pattern");
     println!("  --output <file.html> - Output HTML file (optional, defaults to input.html)");
     println!("  --combine            - Combine multiple JSONL files into one report");
-    println!("  --title <str>       - Override report title");
+    println!("  --title <str>        - Override report title");
     println!("  --host <str>         - Override hostname");
     println!();
 }
@@ -669,4 +695,170 @@ fn expand_inputs(pattern: &str) -> Result<Vec<String>, Box<dyn std::error::Error
     files.sort();
     
     Ok(files)
+}
+
+fn rot47(buf: &mut [u8]) {
+    for b in buf {
+        if (33..=126).contains(b) {
+            *b = 33 + ((*b - 33 + 94 - 47) % 94);
+        }
+    }
+}
+
+use std::env;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+
+fn encode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+
+    if path.is_dir() {
+        let dir = fs::read_dir(path)?;
+
+        let mut found_files = false;
+
+        for entry in dir {
+            
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            let file = entry.path();
+
+            if file.is_dir() {
+                continue;
+            }
+
+            found_files = true;
+
+            match encode(&file) {
+                Err(e) => {
+                    log_warn(&format!("File {} failed to encode because {}", file.to_str().unwrap(), e));
+                }
+                _ => {}
+            }
+        }
+
+        if !found_files {
+            log_error(&format!("No files were found in {}", path.display()));
+        }
+
+        return Ok(());
+    }
+
+    let ext = match path.extension().and_then(|e| e.to_str()) {
+        Some("yar") => "ryar",
+        Some("ryar") => return Err(format!("file is already encoded").into()),
+        Some(ext) => return Err(format!("file extension is unsupported: .{}", ext).into()),
+        None => return Err("file has no extension".into())
+    };
+
+    let new_path = path.with_extension(ext);
+
+    // Here `path` is guaranteed to be a file.
+    let input = File::open(path)?;
+    let mut reader = BufReader::new(input);
+
+    let output = File::create(new_path)?;
+    let mut writer = BufWriter::new(output);
+
+    let mut buffer = [0u8; 64 * 1024];
+
+    loop {
+        let n = reader.read(&mut buffer)?;
+        if n == 0 {
+            break;
+        }
+
+        rot47(&mut buffer[..n]);
+
+        writer.write_all(&buffer[..n])?;
+    }
+
+    writer.flush()?;
+
+    if let Err(e) = fs::remove_file(path) {
+        log_warn(&format!("Original file {} failed to delete. {}", path.display(), e));
+    }
+
+    log_success(&format!("Successfully encoded file: {}", path.display()));
+
+    Ok(())
+}
+
+fn decode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+
+    if path.is_dir() {
+        let dir = fs::read_dir(path)?;
+
+        let mut found_files = false;
+
+        for entry in dir {
+            
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            let file = entry.path();
+
+            if file.is_dir() {
+                continue;
+            }
+
+            found_files = true;
+
+            match decode(&file) {
+                Err(e) => {
+                    log_warn(&format!("File {} failed to decode because {}", file.to_str().unwrap(), e));
+                }
+                _ => {}
+            }
+        }
+
+        if !found_files {
+            log_error(&format!("No files were found in {}", path.display()));
+        }
+
+        return Ok(());
+    }
+
+    let ext = match path.extension().and_then(|e| e.to_str()) {
+        Some("ryar") => "yar",
+        Some("yar") => return Err(format!("file is already decoded").into()),
+        Some(ext) => return Err(format!("file extension is unsupported: .{}", ext).into()),
+        None => return Err("file has no extension".into())
+    };
+
+    let new_path = path.with_extension(ext);
+
+    // Here `path` is guaranteed to be a file.
+    let input = File::open(path)?;
+    let mut reader = BufReader::new(input);
+
+    let output = File::create(new_path)?;
+    let mut writer = BufWriter::new(output);
+
+    let mut buffer = [0u8; 64 * 1024];
+
+    loop {
+        let n = reader.read(&mut buffer)?;
+        if n == 0 {
+            break;
+        }
+
+        rot47(&mut buffer[..n]);
+
+        writer.write_all(&buffer[..n])?;
+    }
+
+    writer.flush()?;
+
+    if let Err(e) = fs::remove_file(path) {
+        log_warn(&format!("Original file {} failed to delete. {}", path.display(), e));
+    }
+
+    log_success(&format!("Successfully decoded file: {}", path.display()));
+
+    Ok(())
 }

--- a/src/loki_util/main.rs
+++ b/src/loki_util/main.rs
@@ -705,7 +705,6 @@ fn rot47(buf: &mut [u8]) {
     }
 }
 
-use std::env;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 

--- a/src/loki_util/main.rs
+++ b/src/loki_util/main.rs
@@ -150,7 +150,7 @@ fn print_usage() {
     println!("  {}  - Update Loki-RS program and signatures", "upgrade".green());
     println!("  {}     - Generate HTML report from JSONL file(s)", "html".green());
     println!("  {}   - Encode YARA rules to reduce AV false positives", "encode".green());
-    println!("  {}   - Decode YARA rules to back to its original form", "decode".green());
+    println!("  {}   - Decode YARA rules back to their original form", "decode".green());
     println!();
     println!("Encoding and decoding:");
     println!("  loki-util encode <file/dir>");

--- a/src/loki_util/main.rs
+++ b/src/loki_util/main.rs
@@ -94,23 +94,13 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        "encode" => {
+        "encode" | "decode" => {
             if args.len() != 3 {
-                log_error(&format!("Arguments error\nUsage: loki-util encode <file/dir>"));
+                log_error(&format!("Arguments error\nUsage: loki-util {} <file/dir>", command));
                 std::process::exit(1);
             }
-            if let Err(e) = encode(Path::new(&args[2])) {
+            if let Err(e) = convert_rule_file(Path::new(&args[2]), command) {
                 log_error(&format!("File {} failed to encode because {}", &args[2], e));
-                std::process::exit(1);
-            }
-        }
-        "decode" => {
-            if args.len() != 3 {
-                log_error(&format!("Arguments error\nUsage: loki-util decode <file/dir>"));
-                std::process::exit(1);
-            }
-            if let Err(e) = decode(Path::new(&args[2])) {
-                log_error(&format!("File {} failed to decode because {}", &args[2], e));
                 std::process::exit(1);
             }
         }
@@ -708,8 +698,7 @@ fn rot47(buf: &mut [u8]) {
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 
-fn encode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-
+fn convert_rule_file(path: &Path, convert_type: &str) -> Result<(), Box<dyn std::error::Error>> {
     if path.is_dir() {
         let dir = fs::read_dir(path)?;
 
@@ -730,9 +719,9 @@ fn encode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 
             found_files = true;
 
-            match encode(&file) {
+            match convert_rule_file(&file, convert_type) {
                 Err(e) => {
-                    log_warn(&format!("File {} failed to encode because {}", file.display(), e));
+                    log_warn(&format!("File {} failed to {} because {}", file.display(), convert_type, e));
                 }
                 _ => {}
             }
@@ -746,8 +735,20 @@ fn encode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let ext = match path.extension().and_then(|e| e.to_str()) {
-        Some("yar") => "ryar",
-        Some("ryar") => return Err(format!("file is already encoded").into()),
+        Some("yar") => {
+            match convert_type {
+                "encode" => "ryar",
+                "decode" => return Err(format!("file is already decoded").into()),
+                _ => return Err("unknown convert_type".into())
+            }
+        }
+        Some("ryar") => {
+            match convert_type {
+                "encode" => return Err(format!("file is already encoded").into()),
+                "decode" => "yar",
+                _ => return Err("unknown convert_type".into())
+            }
+        }
         Some(ext) => return Err(format!("file extension is unsupported: .{}", ext).into()),
         None => return Err("file has no extension".into())
     };
@@ -780,84 +781,7 @@ fn encode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         log_warn(&format!("Original file {} failed to delete. {}", path.display(), e));
     }
 
-    log_success(&format!("Successfully encoded file: {}", path.display()));
-
-    Ok(())
-}
-
-fn decode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-
-    if path.is_dir() {
-        let dir = fs::read_dir(path)?;
-
-        let mut found_files = false;
-
-        for entry in dir {
-            
-            let entry = match entry {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-
-            let file = entry.path();
-
-            if file.is_dir() {
-                continue;
-            }
-
-            found_files = true;
-
-            match decode(&file) {
-                Err(e) => {
-                    log_warn(&format!("File {} failed to decode because {}", file.display(), e));
-                }
-                _ => {}
-            }
-        }
-
-        if !found_files {
-            log_error(&format!("No files were found in {}", path.display()));
-        }
-
-        return Ok(());
-    }
-
-    let ext = match path.extension().and_then(|e| e.to_str()) {
-        Some("ryar") => "yar",
-        Some("yar") => return Err(format!("file is already decoded").into()),
-        Some(ext) => return Err(format!("file extension is unsupported: .{}", ext).into()),
-        None => return Err("file has no extension".into())
-    };
-
-    let new_path = path.with_extension(ext);
-
-    // Here `path` is guaranteed to be a file.
-    let input = File::open(path)?;
-    let mut reader = BufReader::new(input);
-
-    let output = File::create(new_path)?;
-    let mut writer = BufWriter::new(output);
-
-    let mut buffer = [0u8; 64 * 1024];
-
-    loop {
-        let n = reader.read(&mut buffer)?;
-        if n == 0 {
-            break;
-        }
-
-        rot47(&mut buffer[..n]);
-
-        writer.write_all(&buffer[..n])?;
-    }
-
-    writer.flush()?;
-
-    if let Err(e) = fs::remove_file(path) {
-        log_warn(&format!("Original file {} failed to delete. {}", path.display(), e));
-    }
-
-    log_success(&format!("Successfully decoded file: {}", path.display()));
+    log_success(&format!("Successfully {}d file: {}", convert_type, path.display()));
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -781,6 +781,38 @@ fn get_filename_ioc_type(_filename_ioc_value: &str) -> FilenameIOCType {
     FilenameIOCType::Regex
 } 
 
+// Apply ROT47 encoding/decoding to a byte buffer.
+fn rot47(buf: &mut [u8]) {
+    for b in buf {
+        if (33..=126).contains(b) {
+            *b = 33 + ((*b - 33 + 94 - 47) % 94);
+        }
+    }
+}
+
+// Read a YARA rule file.
+// `.yar` files are read directly, while `.ryar` files are ROT47-decoded.
+// Returns the rule file contents as a UTF-8 string.
+fn read_rule_file(path: &std::path::Path) -> std::io::Result<String> {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("yar") => fs::read_to_string(path),
+        Some("ryar") => {
+            let mut bytes = fs::read(path)?;
+            rot47(&mut bytes);
+            Ok(
+                String::from_utf8(bytes)
+                    .map_err(|e| std::io::Error::new(
+                        std::io::ErrorKind::InvalidData, e
+                    ))?
+            )
+        }
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "unsupported rule extension",
+        )),
+    }
+}
+
 // Initialize the rule files
 // Returns (compiled_rules, rule_count)
 fn initialize_yara_rules(logger: &UnifiedLogger) -> Result<(Rules, usize), String> {
@@ -800,7 +832,12 @@ fn initialize_yara_rules(logger: &UnifiedLogger) -> Result<(Rules, usize), Strin
     // Filter 
     let filtered_files = files
         .filter_map(Result::ok)
-        .filter(|d| if let Some(e) = d.path().extension() { e == "yar" } else { false })
+        .filter(|d| {
+            matches!(
+                d.path().extension().and_then(|e| e.to_str()),
+                Some("yar" | "ryar")
+            )
+        })
         .into_iter();
     // Test compile each rule
     for file in filtered_files {
@@ -809,7 +846,7 @@ fn initialize_yara_rules(logger: &UnifiedLogger) -> Result<(Rules, usize), Strin
             file.path().to_string_lossy()
         ));
         // Read the rule file
-        let rules_string = match fs::read_to_string(file.path()) {
+        let rules_string = match read_rule_file(&file.path()) {
             Ok(content) => content,
             Err(e) => {
                 logger.error(&format!("Unable to read YARA rule file {:?}: {:?}", file.path(), e));

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ use crate::helpers::html_report;
 use crate::helpers::unified_logger::{UnifiedLogger, LoggerConfig, RemoteConfig, RemoteProtocol, RemoteFormat, LogLevel, TuiMessage};
 use crate::helpers::interrupt::ScanState;
 use crate::helpers::tui::run_tui;
+use crate::helpers::codec::rot47;
 use crate::modules::{ScanModule, ScanContext};
 use crate::modules::process_check::ProcessCheckModule;
 use crate::modules::filesystem_scan::{FileScanModule, enumerate_drives};
@@ -791,15 +792,6 @@ fn initialize_filename_iocs(logger: &UnifiedLogger) -> Vec<FilenameIOC> {
 fn get_filename_ioc_type(_filename_ioc_value: &str) -> FilenameIOCType {
     FilenameIOCType::Regex
 } 
-
-// Apply ROT47 encoding/decoding to a byte buffer.
-fn rot47(buf: &mut [u8]) {
-    for b in buf {
-        if (33..=126).contains(b) {
-            *b = 33 + ((*b - 33 + 94 - 47) % 94);
-        }
-    }
-}
 
 // Read a YARA rule file.
 // `.yar` files are read directly, while `.ryar` files are ROT47-decoded.


### PR DESCRIPTION
## Overview

This pull request adds support for ROT47-encoded YARA rule files (`.ryar`). The feature allows YARA rules to be stored in an encoded format and transparently decoded at runtime before compilation.

The primary goal is to reduce false positive detections from security products that may flag plain-text YARA signatures while preserving full compatibility with existing `.yar` rule files.

## Features Implemented

* Added support for loading ROT47-encoded YARA rule files (`.ryar`)
* Automatically detects rule file extension and decodes `.ryar` files before compiling
* Maintains full support for standard `.yar` rule files
* Introduced reusable helper function for reading both encoded and unencoded rule files
* Added in-place ROT47 encoder/decoder implementation

## New Command Line Options

The following commands were added to `loki-util`:

* `loki-util encode <file/dir>` - Encode YARA rule files using ROT47 and save them as `.ryar`
* `loki-util decode <file/dir>` - Decode `.ryar` files back to their original `.yar` format

## Files Modified

* `src/main.rs` - Added support for loading and decoding `.ryar` rule files before YARA compilation
* `src/loki_util/main.rs` - Added ROT47 encoding/decoding helper and unified rule file reader

## Result

Users can now distribute and store YARA rules in an encoded `.ryar` format, helping reduce false positive detections from security software while keeping the loading process completely transparent. Existing `.yar` rule files continue to work without any changes.
